### PR TITLE
Send OnConnect and OnAccept events before starting threads

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -632,9 +632,9 @@ mod test {
             stats.add(s)
         }
 
-        assert_eq!(stats.connect_count + stats.accept_count,
-                   NETWORK_SIZE * (NETWORK_SIZE - 1));
-        assert_eq!(stats.messages_count,  NETWORK_SIZE * MESSAGE_PER_NODE * (NETWORK_SIZE - 1));
+        assert_eq!(stats.connect_count,  NETWORK_SIZE * (NETWORK_SIZE - 1) / 2);
+        assert_eq!(stats.accept_count,   NETWORK_SIZE * (NETWORK_SIZE - 1) / 2);
+        assert_eq!(stats.messages_count, NETWORK_SIZE * (NETWORK_SIZE - 1) * MESSAGE_PER_NODE);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -200,10 +200,13 @@ impl State {
 
         debug_assert!(!self.connections.contains_key(&connection));
         let (tx, rx) = mpsc::channel();
-        self.start_writing_thread(trans.sender, connection.clone(), rx);
-        self.start_reading_thread(trans.receiver, connection.clone());
+
         let _ = self.connections.insert(connection, tx);
         let _ = self.event_sender.send(event_to_user);
+
+        self.start_writing_thread(trans.sender, connection.clone(), rx);
+        self.start_reading_thread(trans.receiver, connection.clone());
+
         Ok(trans.connection_id)
     }
 


### PR DESCRIPTION
Seems to fix the halting 'network' test problem
